### PR TITLE
Add NEW_RELIC_MONITOR_MODE config option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@ NEW_RELIC_REGION=US                        # US or EU (default: US)
 NEW_RELIC_LICENSE_KEY=                     # For APM monitoring of this service (optional)
 NEW_RELIC_APP_NAME=mcp-server-newrelic     # APM application name
 NEW_RELIC_ENVIRONMENT=development          # Environment tag for APM
+NEW_RELIC_MONITOR_MODE=true                # Enable/disable APM monitor mode
 
 # Server Configuration
 MCP_TRANSPORT=stdio                        # Transport: stdio, http, or sse (default: stdio)

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ NEW_RELIC_REGION=US  # or EU (both regions supported)
 # Optional: New Relic APM (for monitoring the server itself)
 NEW_RELIC_LICENSE_KEY=your-license-key
 NEW_RELIC_APP_NAME=mcp-server-newrelic
+NEW_RELIC_MONITOR_MODE=true
 
 # Server Configuration
 MCP_TRANSPORT=stdio  # stdio, http, or sse

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       - NEW_RELIC_ACCOUNT_ID=${NEW_RELIC_ACCOUNT_ID}
       - NEW_RELIC_LICENSE_KEY=${NEW_RELIC_LICENSE_KEY}
       - NEW_RELIC_APP_NAME=${NEW_RELIC_APP_NAME:-mcp-server-newrelic}
+      - NEW_RELIC_MONITOR_MODE=${NEW_RELIC_MONITOR_MODE:-true}
       - NEW_RELIC_REGION=${NEW_RELIC_REGION:-US}
       - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-mcp-server-newrelic}
       # Server Configuration

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -446,6 +446,7 @@ Available metrics:
 # Add to environment configuration
 NEW_RELIC_LICENSE_KEY=your_license_key
 NEW_RELIC_APP_NAME=mcp-server-production
+NEW_RELIC_MONITOR_MODE=true
 NEW_RELIC_DISTRIBUTED_TRACING_ENABLED=true
 ```
 


### PR DESCRIPTION
## Summary
- add `NEW_RELIC_MONITOR_MODE` to `.env.example`
- document the variable in README and deployment guide
- include it in docker-compose environment settings

## Testing
- `go test ./...` *(fails: missing fields in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6856bdb9b9a48326af6050314d980ca9